### PR TITLE
feat: add structured debug logging and tool-call aware chat handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ upload
 *.exe
 *.db
 build
+
+genspark2api
+genspark2api-macos

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ docker run -d --name genspark2api \
     - **gpt-5.1**
     - **gpt-5.1-high**
     - **gpt-5-pro**
+    - **gpt-5.2**
+    - **gpt-5.2-pro**
     - ~~**gpt-5-minimal**~~
     - ~~**gpt-5**~~
     - ~~**gpt-5-high**~~

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="right">
-   <strong>中文</strong> 
+   <strong>中文 | <a href="README_EN.md">English</a></strong> 
 </p>
 <div align="center">
 
@@ -13,6 +13,31 @@ _觉得有点意思的话 别忘了点个 ⭐_
 
 <sup><i>AI Wave 社群</i></sup> · <sup><i>(群内提供公益API、AI机器人)</i></sup>
 
+---
+
+**Genspark2API** 是一个使用 Go 语言编写的高性能代理服务，用于将 **Genspark.ai** 的能力封装为 **兼容 OpenAI 标准的 API 接口**。
+
+### 🌟 核心特性
+
+- 🤖 **对话大模型**：支持 GPT-5.1 系列、Claude Opus/Sonnet 4.5、Gemini 3、O3-Pro 等主流模型
+- 🖼️ **文生图能力**：支持 DALL·E、Flux、Imagen4 等多种绘图模型
+- 🎬 **文/图生视频**：支持 Sora-2、Veo3、Kling、Runway 等视频生成模型
+- 🔄 **OpenAI API 兼容**：可直接接入任何兼容 OpenAI 的客户端/中间件
+- 🛡️ **智能防护绕过**：内置 Cloudflare 与 ReCaptcha v3 相关处理逻辑（需按文档配置）
+- 🔀 **多 Cookie 池轮询**：自动在多个账号之间分流，请求失败自动切换重试
+- 🔧 **Tool Calling 支持**：支持 OpenAI 风格的工具调用（function calling）
+- 🌐 **联网搜索**：模型名后加 `-search` 即可开启联网搜索（如: `gpt-5.1-search`）
+- 📊 **流式响应**：支持 SSE 流式输出，体验与官方 OpenAI 接口一致
+
+### 📦 快速开始
+
+```bash
+docker run -d --name genspark2api \
+  -p 7055:7055 \
+  -e GS_COOKIE="你的_genspark_cookie" \
+  -e API_SECRET="你的_api_secret" \
+  deanxv/genspark2api:latest
+```
 
 </div>
 
@@ -23,27 +48,33 @@ _觉得有点意思的话 别忘了点个 ⭐_
 ## 功能
 
 - [x] 支持对话接口(流式/非流式)(`/chat/completions`)(请求非以下列表的模型会触发`Mixture-of-Agents`模式)
-    - **gpt-5-minimal**
-    - **gpt-5**
-    - **gpt-5-high**
+    - **gpt-5.1-low**
+    - **gpt-5.1**
+    - **gpt-5.1-high**
     - **gpt-5-pro**
-    - **gpt-4.1**
-    - **o1**
-    - **o3**
+    - ~~**gpt-5-minimal**~~
+    - ~~**gpt-5**~~
+    - ~~**gpt-5-high**~~
+    - ~~**gpt-4.1**~~
+    - ~~**o1**~~
+    - ~~**o3**~~
     - **o3-pro**
-    - **o4-mini-high**
-    - **claude-3-7-sonnet-thinking**
-    - **claude-3-7-sonnet**
+    - ~~**o4-mini-high**~~
+    - ~~**claude-3-7-sonnet-thinking**~~
+    - ~~**claude-3-7-sonnet**~~
     - **claude-sonnet-4-5**
-    - **claude-sonnet-4-thinking**
-    - **claude-sonnet-4**
+    - ~~**claude-sonnet-4-thinking**~~
+    - ~~**claude-sonnet-4**~~
+    - **claude-opus-4-5**
     - **claude-opus-4-1**
-    - **claude-opus-4**
+    - **claude-4-5-haiku**
+    - ~~**claude-opus-4**~~
     - **gemini-2.5-pro**
-    - **gemini-2.5-flash**
-    - **gemini-2.0-flash**
-    - **deep-seek-v3**
-    - **deep-seek-r1**
+    - **gemini-3-pro-preview**
+    - ~~**gemini-2.5-flash**~~
+    - ~~**gemini-2.0-flash**~~
+    - ~~**deep-seek-v3**~~
+    - ~~**deep-seek-r1**~~
     - **grok-4-0709**
 - [x] 支持**联网搜索**,在模型名后添加`-search`即可(如:`gpt-4o-search`)
 - [x] 支持识别**图片**/**文件**多轮对话

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _觉得有点意思的话 别忘了点个 ⭐_
 - 🔄 **OpenAI API 兼容**：可直接接入任何兼容 OpenAI 的客户端/中间件
 - 🛡️ **智能防护绕过**：内置 Cloudflare 与 ReCaptcha v3 相关处理逻辑（需按文档配置）
 - 🔀 **多 Cookie 池轮询**：自动在多个账号之间分流，请求失败自动切换重试
-- 🔧 **Tool Calling 支持**：支持 OpenAI 风格的工具调用（function calling）
+- 🔧 **Tool Calling 支持**：支持 OpenAI 风格的工具调用（function calling），可通过 `TOOL_CALLING_ENABLED=0` 关闭
 - 🌐 **联网搜索**：模型名后加 `-search` 即可开启联网搜索（如: `gpt-5.1-search`）
 - 📊 **流式响应**：支持 SSE 流式输出，体验与官方 OpenAI 接口一致
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,378 @@
+<p align="right">
+   <strong><a href="README.md">中文</a> | English</strong> 
+</p>
+<div align="center">
+
+# Genspark2API
+
+_If you find this interesting, don't forget to give it a ⭐_
+
+<a href="https://t.me/+LGKwlC_xa-E5ZDk9">
+  <img src="https://img.shields.io/badge/Telegram-AI Wave Community-0088cc?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram Community" />
+</a>
+
+<sup><i>AI Wave Community</i></sup> · <sup><i>(Provides free APIs and AI bots)</i></sup>
+
+---
+
+**Genspark2API** is a high-performance proxy server written in Go that wraps **Genspark.ai** capabilities into **OpenAI-compatible API endpoints**.
+
+### 🌟 Core Features
+
+- 🤖 **Conversational AI Models**: Support for GPT-5.1 series, Claude Opus/Sonnet 4.5, Gemini 3, O3-Pro and other mainstream models
+- 🖼️ **Text-to-Image**: Support for DALL·E, Flux, Imagen4 and various drawing models
+- 🎬 **Text/Image-to-Video**: Support for Sora-2, Veo3, Kling, Runway and other video generation models
+- 🔄 **OpenAI API Compatible**: Direct integration with any OpenAI-compatible clients/middleware
+- 🛡️ **Smart Protection Bypass**: Built-in Cloudflare and ReCaptcha v3 handling logic (requires configuration per documentation)
+- 🔀 **Multi-Cookie Pool Rotation**: Automatic load distribution across multiple accounts with failover retry
+- 🔧 **Tool Calling Support**: Support for OpenAI-style function calling
+- 🌐 **Web Search**: Add `-search` suffix to model name to enable web search (e.g., `gpt-5.1-search`)
+- 📊 **Streaming Response**: SSE streaming output with experience identical to official OpenAI API
+
+### 📦 Quick Start
+
+```bash
+docker run -d --name genspark2api \
+  -p 7055:7055 \
+  -e GS_COOKIE="your_genspark_cookie" \
+  -e API_SECRET="your_api_secret" \
+  deanxv/genspark2api:latest
+```
+
+</div>
+
+> ⚠️ **Important**: Genspark officially enforces `ReCaptchaV3` validation. 
+> Failure to pass may cause model degradation or image generation issues. Please refer to [genspark-playwright-proxy V3 verification service](#genspark-playwright-prxoy服务过V3验证) and configure the environment variable `RECAPTCHA_PROXY_URL`.
+
+## Features
+
+- [x] Support for chat interface (streaming/non-streaming) (`/chat/completions`) (requesting models not in the following list will trigger `Mixture-of-Agents` mode)
+    - **gpt-5.1-low**
+    - **gpt-5.1**
+    - **gpt-5.1-high**
+    - **gpt-5-pro**
+    - ~~**gpt-5-minimal**~~
+    - ~~**gpt-5**~~
+    - ~~**gpt-5-high**~~
+    - ~~**gpt-4.1**~~
+    - ~~**o1**~~
+    - ~~**o3**~~
+    - **o3-pro**
+    - ~~**o4-mini-high**~~
+    - ~~**claude-3-7-sonnet-thinking**~~
+    - ~~**claude-3-7-sonnet**~~
+    - **claude-sonnet-4-5**
+    - ~~**claude-sonnet-4-thinking**~~
+    - ~~**claude-sonnet-4**~~
+    - **claude-opus-4-5**
+    - **claude-opus-4-1**
+    - **claude-4-5-haiku**
+    - ~~**claude-opus-4**~~
+    - **gemini-2.5-pro**
+    - **gemini-3-pro-preview**
+    - ~~**gemini-2.5-flash**~~
+    - ~~**gemini-2.0-flash**~~
+    - ~~**deep-seek-v3**~~
+    - ~~**deep-seek-r1**~~
+    - **grok-4-0709**
+- [x] Support for **web search** by adding `-search` suffix to model name (e.g., `gpt-4o-search`)
+- [x] Support for **image**/**file** recognition in multi-turn conversations
+- [x] Support for text-to-image interface (`/images/generations`)
+    - **fal-ai/nano-banana**
+    - **fal-ai/bytedance/seedream/v4**
+    - **gpt-image-1**
+    - **flux-pro/ultra**
+    - **flux-pro/kontext/pro**
+    - **imagen4**
+- [x] Support for text/image-to-video interface (`/videos/generations`), see [Video Generation Request Format](#生视频请求格式)
+- [x] Support for custom request header validation (Authorization)
+- [x] Support for cookie pool (random)
+- [x] Support for automatic cookie switching retry on request failure (requires cookie pool configuration)
+- [x] Configurable automatic chat record deletion
+- [x] Configurable proxy requests (environment variable `PROXY_URL`)
+- [x] Configurable Model-Chat binding (solves model auto-switching causing **intelligence degradation**), see [Advanced Configuration](#解决模型自动切换导致降智问题)
+
+### API Documentation:
+
+Omitted
+
+### Example:
+
+<span><img src="docs/img2.png" width="800"/></span>
+
+## How to Use
+
+Omitted
+
+## How to Integrate with NextChat
+
+Fill in the interface address (ip:port/domain) and API-Key (`PROXY_SECRET`), everything else can be filled randomly.
+
+> If you haven't built your own NextChat panel, here's one that's already set up: [NeatChat](https://ai.aytsao.cn/)
+
+<span><img src="docs/img5.png" width="800"/></span>
+
+## How to Integrate with one-api
+
+Fill in the `BaseURL` (ip:port/domain) and key (`PROXY_SECRET`), everything else can be filled randomly.
+
+<span><img src="docs/img3.png" width="800"/></span>
+
+## Deployment
+
+### Deploy using Docker-Compose (All In One)
+
+```shell
+docker-compose pull && docker-compose up -d
+```
+
+#### docker-compose.yml
+
+```docker
+version: '3.4'
+
+services:
+  genspark2api:
+    image: deanxv/genspark2api:latest
+    container_name: genspark2api
+    restart: always
+    ports:
+      - "7055:7055"
+    volumes:
+      - ./data:/app/genspark2api/data
+    environment:
+      - GS_COOKIE=******  # cookie (multiple separated by commas)
+      - API_SECRET=123456  # [Optional] Interface key - modify this line for request header validation value (multiple separated by commas)
+      - TZ=Asia/Shanghai
+```
+
+### Deploy using Docker
+
+```docker
+docker run --name genspark2api -d --restart always \
+-p 7055:7055 \
+-v $(pwd)/data:/app/genspark2api/data \
+-e GS_COOKIE=***** \
+-e API_SECRET="123456" \
+-e TZ=Asia/Shanghai \
+deanxv/genspark2api
+```
+
+Replace `API_SECRET` and `GS_COOKIE` with your own values.
+
+If the above image cannot be pulled, try using the GitHub Docker image by replacing `deanxv/genspark2api` with `ghcr.io/deanxv/genspark2api`.
+
+### Deploy to Third-Party Platforms
+
+<details>
+<summary><strong>Deploy to Zeabur</strong></summary>
+<div>
+
+[![Deployed on Zeabur](https://zeabur.com/deployed-on-zeabur-dark.svg)](https://zeabur.com?referralCode=deanxv&utm_source=deanxv)
+
+> Zeabur's servers are overseas, automatically solving network issues, ~~and the free quota is sufficient for personal use~~
+
+1. First **fork** a copy of the code.
+2. Go to [Zeabur](https://zeabur.com?referralCode=deanxv), log in with GitHub, enter the console.
+3. In Service -> Add Service, select Git (first-time use requires authorization), select your forked repository.
+4. Deploy will start automatically, cancel it first.
+5. Add environment variables
+
+   `GS_COOKIE:******`  cookie (multiple separated by commas)
+
+   `API_SECRET:123456` [Optional] Interface key - modify this line for request header validation value (multiple separated by commas) (same usage as openai-API-KEY)
+
+Save.
+
+6. Select Redeploy.
+
+</div>
+
+</details>
+
+<details>
+<summary><strong>Deploy to Render</strong></summary>
+<div>
+
+> Render provides free quota, and you can further increase the quota by binding a card
+
+Render can deploy docker images directly without forking the repository: [Render](https://dashboard.render.com)
+
+</div>
+</details>
+
+## Configuration
+
+### Environment Variables
+
+1. `PORT=7055` [Optional] Port, default is 7055
+2. `DEBUG=true` [Optional] DEBUG mode, can print more information [true: on, false: off]
+3. `API_SECRET=123456` [Optional] Interface key - modify this line for request header (Authorization) validation value (same as API-KEY) (multiple separated by commas)
+4. `GS_COOKIE=******` cookie (multiple separated by commas)
+5. `AUTO_DEL_CHAT=0` [Optional] Automatically delete chat after completion (default: 0) [0: off, 1: on]
+6. `REQUEST_RATE_LIMIT=60` [Optional] Single IP request rate limit per minute, default: 60 times/min
+7. `PROXY_URL=http://127.0.0.1:10801` [Optional] Proxy
+8. `RECAPTCHA_PROXY_URL=http://127.0.0.1:7022` [Optional] genspark-playwright-proxy verification service address, just fill in the domain or ip:port. (Example: `RECAPTCHA_PROXY_URL=https://genspark-playwright-proxy.com` or `RECAPTCHA_PROXY_URL=http://127.0.0.1:7022`), see [genspark-playwright-proxy V3 verification service](#genspark-playwright-prxoy服务过V3验证)
+9. `AUTO_MODEL_CHAT_MAP_TYPE=1` [Optional] Automatically configure Model-Chat binding (default: 1) [0: off, 1: on]
+10. `MODEL_CHAT_MAP=claude-3-7-sonnet=a649******00fa,gpt-4o=su74******47hd` [Optional] Model-Chat binding (multiple separated by commas), see [Advanced Configuration](#解决模型自动切换导致降智问题)
+11. `ROUTE_PREFIX=hf` [Optional] Route prefix, default is empty, interface example after adding this variable: `/hf/v1/chat/completions`
+12. `RATE_LIMIT_COOKIE_LOCK_DURATION=600` [Optional] Cookie disable time when rate limit is reached, default is 600s
+13. `REASONING_HIDE=0` [Optional] **Hide** reasoning process (default: 0) [0: off, 1: on]
+
+~~14. `SESSION_IMAGE_CHAT_MAP=aed9196b-********-4ed6e32f7e4d=0c6785e6-********-7ff6e5a2a29c,aefwer6b-********-casds22=fda234-********-sfaw123` [Optional] Session-Image-Chat binding (multiple separated by commas), see [Advanced Configuration](#生图模型配置)~~
+
+~~15. `YES_CAPTCHA_CLIENT_KEY=******` [Optional] YesCaptcha Client Key for Google verification, see [Using YesCaptcha for Google Verification](#使用YesCaptcha过谷歌验证)~~
+
+### How to Get Cookies
+
+1. Open **F12** developer tools.
+2. Initiate a conversation.
+3. Click the ask request, the **cookie** in the request header is the value needed for the environment variable **GS_COOKIE**.
+
+> **Note:** The `session_id=f9c60******cb6d` part is required, other content is optional, i.e., environment variable `GS_COOKIE=session_id=f9c60******cb6d`
+
+![img.png](docs/img.png)
+
+## Advanced Configuration
+
+### Solving Model Auto-Switching Causing Intelligence Degradation
+
+#### Method 1 (This configuration is enabled by default) [Recommended]
+
+> Configure environment variable **AUTO_MODEL_CHAT_MAP_TYPE=1**
+>
+> Under this configuration, the conversation ID will be obtained when calling the model and bind the model.
+
+#### Method 2
+
+> Configure environment variable MODEL_CHAT_MAP
+>
+> **Purpose:** Specify conversations to solve model auto-switching causing intelligence degradation.
+
+1. Open **F12** developer tools.
+2. Select the model for the conversation you want to bind (example: `claude-3-7-sonnet`), initiate a conversation.
+3. Click the ask request, the `id` in the top URL (or `id` in the response) is the unique ID for this conversation.
+   ![img.png](docs/img4.png)
+4. Configure environment variable `MODEL_CHAT_MAP=claude-3-7-sonnet=3cdcc******474c5` (multiple separated by commas)
+
+### genspark-playwright-proxy Service for V3 Verification
+
+1. Deploy genspark-playwright-proxy with docker
+
+#### docker
+
+```docker 
+docker run --name genspark-playwright-proxy -d --restart always \
+-p 7022:7022 \
+-v $(pwd)/data:/app/genspark-playwright-proxy/data \
+-e PROXY_URL=http://account:pwd@ip:port #  [Optional] Recommended residential dynamic proxy, configuring proxy increases verification success rate but slows response.
+-e TZ=Asia/Shanghai \
+deanxv/genspark-playwright-proxy
+```
+
+#### docker-compose
+
+```docker-compose
+version: '3.4'
+
+services:
+  genspark-playwright-proxy:
+    image: deanxv/genspark-playwright-proxy:latest
+    container_name: genspark-playwright-proxy
+    restart: always
+    ports:
+      - "7022:7022"
+    volumes:
+      - ./data:/app/genspark-playwright-proxy/data
+    environment:
+      - PROXY_URL=http://account:pwd@ip:port #  [Optional] Recommended residential dynamic proxy, configuring proxy increases verification success rate but slows response.
+```
+
+2. After deployment, configure `genspark2api` environment variable `RECAPTCHA_PROXY_URL`, just fill in the domain or ip:port. (Example: `RECAPTCHA_PROXY_URL=https://genspark-playwright-proxy.com` or `RECAPTCHA_PROXY_URL=http://127.0.0.1:7022`)
+
+3. Restart `genspark2api` service.
+
+#### Integrating Custom Recaptcha Service
+
+###### API: Get Token
+
+###### Basic Information
+
+- **API Endpoint**: `/genspark`
+- **Request Method**: GET
+- **API Description**: Get user authentication token
+
+###### Request Parameters
+
+###### Request Headers
+
+| Parameter | Required | Type   | Description      |
+|-----------|----------|--------|------------------|
+| cookie    | Yes      | string | User session credentials |
+
+###### Response Parameters
+
+###### Response Example
+
+```json
+{
+  "code": 200,
+  "token": "ey********pe"
+}
+```
+
+## Error Troubleshooting
+
+> `Detected Cloudflare Challenge Page`
+
+Blocked by Cloudflare 5s shield, configure `PROXY_URL`.
+
+([Recommended solution] [Build your own ipv6 proxy pool to bypass cf IP rate limits and 5s shield](https://linux.do/t/topic/367413) or purchase [IProyal](https://iproyal.cn/?r=244330))
+
+> `Genspark Service Unavailable`
+
+Genspark official service is unavailable, please try again later.
+
+> `All cookies are temporarily unavailable.`
+
+All users (cookies) have reached the rate limit, change user cookies or try again later.
+
+## Video Generation Request Format
+
+### Request
+
+**Endpoint**: `POST /v1/videos/generations`
+
+**Content-Type**: `application/json`
+
+#### Request Parameters
+
+| Field        | Type   | Required | Description                      | Accepted Values                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|--------------|--------|----------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| model        | string | Yes      | Video generation model to use     | Model list: `sora-2`\|`sora-2-pro`\|`gemini/veo3`\|`gemini/veo3/fast`\|`kling/v2.5-turbo/pro`\|`fal-ai/bytedance/seedance/v1/pro`\|`minimax/hailuo-02/standard`\|`pixverse/v5`\|`fal-ai/bytedance/seedance/v1/lite`\|`gemini/veo2`\|`wan/v2.2`\|`hunyuan`\|`vidu/start-end-to-video`\|`runway/gen4_turbo` |
+| aspect_ratio | string | Yes      | Video aspect ratio               | `9:16` \| `16:9` \| `3:4` \|`1:1` \| `4:3`                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| duration     | int    | Yes      | Video duration (in seconds)      | Positive integer                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| prompt       | string | Yes      | Text description for video generation | -                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| auto_prompt  | bool   | Yes      | Whether to auto-optimize prompt  | `true` \| `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| image        | string | No       | Base image for video generation (Base64/url) | Base64 string/url                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+
+---
+
+### Response
+
+#### Response Object
+
+```json
+{
+  "created": 1677664796,
+  "data": [
+    {
+      "url": "https://example.com/video.mp4"
+    }
+  ]
+}
+```
+
+## Other
+
+**Genspark** (Register to get 1 month Plus): [https://www.genspark.ai](https://www.genspark.ai/invite?invite_code=YjVjMGRkYWVMZmE4YUw5MDc0TDM1ODlMZDYwMzQ4OTJlNmEx)

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,6 +51,8 @@ docker run -d --name genspark2api \
     - **gpt-5.1**
     - **gpt-5.1-high**
     - **gpt-5-pro**
+    - **gpt-5.2**
+    - **gpt-5.2-pro**
     - ~~**gpt-5-minimal**~~
     - ~~**gpt-5**~~
     - ~~**gpt-5-high**~~

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,7 +25,7 @@ _If you find this interesting, don't forget to give it a ⭐_
 - 🔄 **OpenAI API Compatible**: Direct integration with any OpenAI-compatible clients/middleware
 - 🛡️ **Smart Protection Bypass**: Built-in Cloudflare and ReCaptcha v3 handling logic (requires configuration per documentation)
 - 🔀 **Multi-Cookie Pool Rotation**: Automatic load distribution across multiple accounts with failover retry
-- 🔧 **Tool Calling Support**: Support for OpenAI-style function calling
+- 🔧 **Tool Calling Support**: Support for OpenAI-style function calling (can be disabled via `TOOL_CALLING_ENABLED=0`)
 - 🌐 **Web Search**: Add `-search` suffix to model name to enable web search (e.g., `gpt-5.1-search`)
 - 📊 **Streaming Response**: SSE streaming output with experience identical to official OpenAI API
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -420,3 +420,98 @@ func (sm *SessionMapManager) GetSize() int {
 	defer sm.mu.Unlock()
 	return len(sm.keys)
 }
+
+// GetConfigSummary возвращает строку с конфигурацией для логирования (без секретов)
+func GetConfigSummary() []string {
+	var lines []string
+	lines = append(lines, "========== Configuration Summary ==========")
+
+	// Основные настройки
+	if AutoDelChat == 1 {
+		lines = append(lines, "AUTO_DEL_CHAT: enabled (1)")
+	} else {
+		lines = append(lines, "AUTO_DEL_CHAT: disabled (0)")
+	}
+
+	if AutoModelChatMapType == 1 {
+		lines = append(lines, "AUTO_MODEL_CHAT_MAP_TYPE: save sessions (1)")
+	} else {
+		lines = append(lines, "AUTO_MODEL_CHAT_MAP_TYPE: delete sessions (0)")
+	}
+
+	if ReasoningHide == 1 {
+		lines = append(lines, "REASONING_HIDE: hide reasoning (1)")
+	} else {
+		lines = append(lines, "REASONING_HIDE: show reasoning (0)")
+	}
+
+	if DebugEnabled {
+		lines = append(lines, "DEBUG: enabled")
+	} else {
+		lines = append(lines, "DEBUG: disabled")
+	}
+
+	// Proxy
+	if ProxyUrl != "" {
+		lines = append(lines, "PROXY_URL: configured")
+	} else {
+		lines = append(lines, "PROXY_URL: not set")
+	}
+
+	// Recaptcha
+	if RecaptchaProxyUrl != "" {
+		lines = append(lines, "RECAPTCHA_PROXY_URL: configured")
+	} else {
+		lines = append(lines, "RECAPTCHA_PROXY_URL: not set")
+	}
+
+	// Route prefix
+	if RoutePrefix != "" {
+		lines = append(lines, "ROUTE_PREFIX: "+RoutePrefix)
+	} else {
+		lines = append(lines, "ROUTE_PREFIX: not set")
+	}
+
+	// Cookies count
+	cookiesCount := len(GSCookies)
+	if cookiesCount == 1 {
+		lines = append(lines, "GS_COOKIES_COUNT: 1 cookie")
+	} else {
+		lines = append(lines, "GS_COOKIES_COUNT: multiple cookies configured")
+	}
+
+	// Model chat map
+	if len(ModelChatMap) > 0 {
+		lines = append(lines, "MODEL_CHAT_MAP: configured")
+	} else {
+		lines = append(lines, "MODEL_CHAT_MAP: not set")
+	}
+
+	// Session image chat map
+	if len(SessionImageChatMap) > 0 {
+		lines = append(lines, "SESSION_IMAGE_CHAT_MAP: configured")
+	} else {
+		lines = append(lines, "SESSION_IMAGE_CHAT_MAP: not set")
+	}
+
+	// Pre messages
+	if PRE_MESSAGES_JSON != "" {
+		lines = append(lines, "PRE_MESSAGES_JSON: configured")
+	} else {
+		lines = append(lines, "PRE_MESSAGES_JSON: not set")
+	}
+
+	// YesCaptcha
+	if YesCaptchaClientKey != "" {
+		lines = append(lines, "YES_CAPTCHA_CLIENT_KEY: configured")
+	} else {
+		lines = append(lines, "YES_CAPTCHA_CLIENT_KEY: not set")
+	}
+
+	// Timezone
+	tz, _ := time.Now().Zone()
+	lines = append(lines, "TIMEZONE: "+tz)
+
+	lines = append(lines, "=============================================")
+	return lines
+}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -62,6 +62,7 @@ var DebugEnabled = os.Getenv("DEBUG") == "true"
 // DEBUG_LOG_LEVEL=verbose|normal|minimal
 var DebugLogBody = os.Getenv("DEBUG_LOG_BODY") == "true"
 var DebugLogHeaders = os.Getenv("DEBUG_LOG_HEADERS") == "true"
+var DebugLogNetwork = os.Getenv("DEBUG_LOG_NETWORK") == "true"
 var DebugSavePayloads = os.Getenv("DEBUG_SAVE_PAYLOADS") == "true"
 var DebugLogLevel = env.String("DEBUG_LOG_LEVEL", "normal") // verbose, normal, minimal
 
@@ -463,6 +464,9 @@ func GetConfigSummary() []string {
 		}
 		if DebugLogHeaders {
 			lines = append(lines, "  DEBUG_LOG_HEADERS: enabled")
+		}
+		if DebugLogNetwork {
+			lines = append(lines, "  DEBUG_LOG_NETWORK: enabled")
 		}
 		if DebugSavePayloads {
 			lines = append(lines, "  DEBUG_SAVE_PAYLOADS: enabled")

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -66,6 +66,9 @@ var DebugLogNetwork = os.Getenv("DEBUG_LOG_NETWORK") == "true"
 var DebugSavePayloads = os.Getenv("DEBUG_SAVE_PAYLOADS") == "true"
 var DebugLogLevel = env.String("DEBUG_LOG_LEVEL", "normal") // verbose, normal, minimal
 
+// Tool calling (function calling) support - enabled by default
+var ToolCallingEnabled = env.Int("TOOL_CALLING_ENABLED", 1) == 1
+
 var RateLimitKeyExpirationDuration = 20 * time.Minute
 
 var RequestOutTimeDuration = 5 * time.Minute
@@ -530,6 +533,13 @@ func GetConfigSummary() []string {
 		lines = append(lines, "YES_CAPTCHA_CLIENT_KEY: configured")
 	} else {
 		lines = append(lines, "YES_CAPTCHA_CLIENT_KEY: not set")
+	}
+
+	// Tool calling (function calling)
+	if ToolCallingEnabled {
+		lines = append(lines, "TOOL_CALLING_ENABLED: enabled (1)")
+	} else {
+		lines = append(lines, "TOOL_CALLING_ENABLED: disabled (0)")
 	}
 
 	// Timezone

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -55,6 +55,16 @@ var OnlyOpenaiApi = os.Getenv("ONLY_OPENAI_API")
 
 var DebugEnabled = os.Getenv("DEBUG") == "true"
 
+// Debug logging levels
+// DEBUG_LOG_BODY=true - логировать тело запроса/ответа
+// DEBUG_LOG_HEADERS=true - логировать заголовки
+// DEBUG_SAVE_PAYLOADS=true - сохранять детали в файлы logs/debug/
+// DEBUG_LOG_LEVEL=verbose|normal|minimal
+var DebugLogBody = os.Getenv("DEBUG_LOG_BODY") == "true"
+var DebugLogHeaders = os.Getenv("DEBUG_LOG_HEADERS") == "true"
+var DebugSavePayloads = os.Getenv("DEBUG_SAVE_PAYLOADS") == "true"
+var DebugLogLevel = env.String("DEBUG_LOG_LEVEL", "normal") // verbose, normal, minimal
+
 var RateLimitKeyExpirationDuration = 20 * time.Minute
 
 var RequestOutTimeDuration = 5 * time.Minute
@@ -447,6 +457,16 @@ func GetConfigSummary() []string {
 
 	if DebugEnabled {
 		lines = append(lines, "DEBUG: enabled")
+		lines = append(lines, "  DEBUG_LOG_LEVEL: "+DebugLogLevel)
+		if DebugLogBody {
+			lines = append(lines, "  DEBUG_LOG_BODY: enabled")
+		}
+		if DebugLogHeaders {
+			lines = append(lines, "  DEBUG_LOG_HEADERS: enabled")
+		}
+		if DebugSavePayloads {
+			lines = append(lines, "  DEBUG_SAVE_PAYLOADS: enabled")
+		}
 	} else {
 		lines = append(lines, "DEBUG: disabled")
 	}

--- a/common/constants.go
+++ b/common/constants.go
@@ -55,6 +55,8 @@ var TextModelList = []string{
 	"gpt-5.1",
 	"gpt-5.1-high",
 	"gpt-5-pro",
+	"gpt-5.2",
+	"gpt-5.2-pro",
 	//"o3",
 	"o3-pro",
 	//"claude-3-7-sonnet-thinking",

--- a/common/loggger/structured.go
+++ b/common/loggger/structured.go
@@ -1,0 +1,330 @@
+package logger
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"genspark2api/common/config"
+	"genspark2api/common/helper"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Subsystems for categorizing logs
+const (
+	SubHTTP     = "HTTP"
+	SubTool     = "TOOL"
+	SubCookie   = "COOKIE"
+	SubGenspark = "GENSPARK"
+	SubSchedule = "SCHED"
+	SubSystem   = "SYS"
+)
+
+// DebugPayload stores request/response details for verbose debugging
+type DebugPayload struct {
+	RequestID   string      `json:"request_id"`
+	Timestamp   string      `json:"timestamp"`
+	Subsystem   string      `json:"subsystem"`
+	Phase       string      `json:"phase"`
+	Model       string      `json:"model,omitempty"`
+	Messages    interface{} `json:"messages,omitempty"`
+	Tools       interface{} `json:"tools,omitempty"`
+	RawResponse string      `json:"raw_response,omitempty"`
+	ParsedData  interface{} `json:"parsed_data,omitempty"`
+	Duration    string      `json:"duration,omitempty"`
+	Error       string      `json:"error,omitempty"`
+}
+
+// LogEvent represents a structured log event
+type LogEvent struct {
+	Timestamp   time.Time
+	Level       string
+	Subsystem   string
+	RequestID   string
+	Message     string
+	Phase       string
+	DurationMs  int64
+	ExtraFields map[string]interface{}
+}
+
+// StructuredDebug logs with subsystem and phase info
+func StructuredDebug(ctx context.Context, subsystem, phase, msg string) {
+	if !config.DebugEnabled {
+		return
+	}
+	id := getRequestID(ctx)
+	now := time.Now()
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, subsystem, phase, msg)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// StructuredInfo logs info with subsystem
+func StructuredInfo(ctx context.Context, subsystem, msg string) {
+	id := getRequestID(ctx)
+	now := time.Now()
+	formatted := fmt.Sprintf("[INFO] %v | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, subsystem, msg)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// StructuredWarn logs warning with subsystem
+func StructuredWarn(ctx context.Context, subsystem, msg string) {
+	id := getRequestID(ctx)
+	now := time.Now()
+	formatted := fmt.Sprintf("[WARN] %v | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, subsystem, msg)
+	_, _ = fmt.Fprintln(gin.DefaultErrorWriter, formatted)
+}
+
+// StructuredError logs error with subsystem
+func StructuredError(ctx context.Context, subsystem, msg string) {
+	id := getRequestID(ctx)
+	now := time.Now()
+	formatted := fmt.Sprintf("[ERR] %v | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, subsystem, msg)
+	_, _ = fmt.Fprintln(gin.DefaultErrorWriter, formatted)
+}
+
+// SaveDebugPayload saves detailed debug info to a JSON file
+func SaveDebugPayload(ctx context.Context, payload *DebugPayload) error {
+	if !config.DebugEnabled || !config.DebugSavePayloads || LogDir == "" {
+		return nil
+	}
+
+	// Create debug subdirectory
+	debugDir := filepath.Join(LogDir, "debug")
+	if err := os.MkdirAll(debugDir, 0755); err != nil {
+		return err
+	}
+
+	// Mask sensitive data
+	payload = maskSensitiveData(payload)
+
+	// Generate filename
+	filename := fmt.Sprintf("%s-%s-%s.json",
+		time.Now().Format("20060102-150405"),
+		payload.RequestID,
+		payload.Phase)
+	filepath := filepath.Join(debugDir, filename)
+
+	// Marshal and write
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath, data, 0644)
+}
+
+// LogRequestBody logs the request body in a readable format
+func LogRequestBody(ctx context.Context, body interface{}) {
+	if !config.DebugEnabled || !config.DebugLogBody {
+		return
+	}
+
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	var bodyStr string
+	switch v := body.(type) {
+	case string:
+		bodyStr = v
+	case []byte:
+		bodyStr = string(v)
+	case map[string]interface{}:
+		// Format messages separately for readability
+		if messages, ok := v["messages"]; ok {
+			msgJson, _ := json.MarshalIndent(messages, "  ", "  ")
+			bodyStr = fmt.Sprintf("messages:\n  %s", string(msgJson))
+
+			// Add other fields
+			for k, val := range v {
+				if k != "messages" {
+					bodyStr += fmt.Sprintf("\n%s: %v", k, val)
+				}
+			}
+		} else {
+			data, _ := json.MarshalIndent(v, "", "  ")
+			bodyStr = string(data)
+		}
+	default:
+		data, _ := json.MarshalIndent(body, "", "  ")
+		bodyStr = string(data)
+	}
+
+	// Truncate if too long for console
+	if len(bodyStr) > 2000 && config.DebugLogLevel != "verbose" {
+		bodyStr = bodyStr[:2000] + "\n...(truncated, use DEBUG_LOG_LEVEL=verbose for full output)"
+	}
+
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | \n%s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubHTTP, "REQUEST_BODY", bodyStr)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// LogResponseBody logs the response body
+func LogResponseBody(ctx context.Context, body string, statusCode int) {
+	if !config.DebugEnabled || !config.DebugLogBody {
+		return
+	}
+
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	bodyStr := body
+	// Truncate if too long
+	if len(bodyStr) > 1000 && config.DebugLogLevel != "verbose" {
+		bodyStr = bodyStr[:1000] + "...(truncated)"
+	}
+
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | status=%d, body=%s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubHTTP, "RESPONSE_BODY", statusCode, bodyStr)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// LogModelRawResponse logs the raw response from the model
+func LogModelRawResponse(ctx context.Context, response string) {
+	if !config.DebugEnabled {
+		return
+	}
+
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	// Only log if verbose or body logging enabled
+	if config.DebugLogLevel == "minimal" {
+		return
+	}
+
+	respStr := response
+	if len(respStr) > 500 && config.DebugLogLevel != "verbose" {
+		respStr = respStr[:500] + "...(truncated)"
+	}
+
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubGenspark, "MODEL_RAW_RESPONSE", respStr)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// ShouldLogVerbose returns true if verbose logging is enabled
+func ShouldLogVerbose() bool {
+	return config.DebugEnabled && config.DebugLogLevel == "verbose"
+}
+
+// ShouldLogBody returns true if body logging is enabled
+func ShouldLogBody() bool {
+	return config.DebugEnabled && config.DebugLogBody
+}
+
+// LogToolEvent logs tool-related events with structured format
+func LogToolEvent(ctx context.Context, event string, details map[string]interface{}) {
+	if !config.DebugEnabled {
+		return
+	}
+
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	// Build details string
+	var detailParts []string
+	for k, v := range details {
+		detailParts = append(detailParts, fmt.Sprintf("%s=%v", k, v))
+	}
+	detailStr := strings.Join(detailParts, ", ")
+
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | %s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubTool, event, detailStr)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// LogRequestStart logs the start of a request with timing
+func LogRequestStart(ctx context.Context, model string, hasTools bool) {
+	if !config.DebugEnabled {
+		return
+	}
+
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	toolsInfo := "no"
+	if hasTools {
+		toolsInfo = "yes"
+	}
+
+	formatted := fmt.Sprintf("[DEBUG] %v | %s | %s | %s | model=%s, tools=%s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubHTTP, "REQ_START", model, toolsInfo)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+// LogRequestComplete logs request completion with duration
+func LogRequestComplete(ctx context.Context, status int, duration time.Duration) {
+	id := getRequestID(ctx)
+	now := time.Now()
+
+	formatted := fmt.Sprintf("[INFO] %v | %s | %s | %s | status=%d, duration=%s",
+		now.Format("2006/01/02 - 15:04:05"), id, SubHTTP, "REQ_COMPLETE", status, duration)
+	_, _ = fmt.Fprintln(gin.DefaultWriter, formatted)
+}
+
+func getRequestID(ctx context.Context) string {
+	if ctx == nil {
+		return helper.GenRequestID()
+	}
+	id := ctx.Value(helper.RequestIdKey)
+	if id == nil {
+		return helper.GenRequestID()
+	}
+	if s, ok := id.(string); ok {
+		return s
+	}
+	return helper.GenRequestID()
+}
+
+// maskSensitiveData masks tokens and cookies in the payload
+func maskSensitiveData(payload *DebugPayload) *DebugPayload {
+	// Create a copy to avoid modifying original
+	masked := *payload
+
+	// Mask raw response if it contains sensitive patterns
+	if masked.RawResponse != "" {
+		masked.RawResponse = maskString(masked.RawResponse)
+	}
+
+	return &masked
+}
+
+var sensitivePatterns = regexp.MustCompile(`(?i)(session_id|api_key|token|cookie|bearer|authorization)[=:\s]*[^\s,}"]+`)
+
+func maskString(s string) string {
+	return sensitivePatterns.ReplaceAllStringFunc(s, func(match string) string {
+		parts := strings.SplitN(match, "=", 2)
+		if len(parts) == 2 {
+			return parts[0] + "=***MASKED***"
+		}
+		parts = strings.SplitN(match, ":", 2)
+		if len(parts) == 2 {
+			return parts[0] + ":***MASKED***"
+		}
+		return "***MASKED***"
+	})
+}
+
+// PrettyPrintMessages formats messages for readable logging
+func PrettyPrintMessages(messages interface{}) string {
+	data, err := json.MarshalIndent(messages, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", messages)
+	}
+	// Truncate if too long
+	s := string(data)
+	if len(s) > 500 {
+		return s[:500] + "...(truncated)"
+	}
+	return s
+}

--- a/controller/chat.go
+++ b/controller/chat.go
@@ -1216,11 +1216,11 @@ func processStreamData(c *gin.Context, data string, projectId *string, cookie, r
 		go func(pid string, ck string, mdl string, gc *gin.Context) {
 			ctx := gc.Request.Context()
 			if config.AutoModelChatMapType == 1 {
-				logger.Infof(ctx, "[DELETE] STREAM: Saving session instead of deleting, projectId=%s, model=%s", pid, mdl)
+				logger.Debugf(ctx, "[DELETE] STREAM: Saving session instead of deleting, projectId=%s, model=%s", pid, mdl)
 				config.GlobalSessionManager.AddSession(ck, mdl, pid)
 			} else {
 				if config.AutoDelChat == 1 {
-					logger.Infof(ctx, "[DELETE] STREAM: Auto-delete enabled, projectId=%s, model=%s", pid, mdl)
+					logger.Debugf(ctx, "[DELETE] STREAM: Auto-delete enabled, projectId=%s, model=%s", pid, mdl)
 					client := cycletls.Init()
 					defer safeClose(client)
 					if _, err := makeDeleteRequest(gc, client, ck, pid); err != nil {
@@ -2090,7 +2090,7 @@ func handleToolUseNonStreamRequest(c *gin.Context, client cycletls.CycleTLS, coo
 					go func(pid string, ck string, mdl string, gc *gin.Context) {
 						ctx := gc.Request.Context()
 						if config.AutoDelChat == 1 {
-							logger.Infof(ctx, "[DELETE] TOOL-USE: Auto-delete enabled, projectId=%s, model=%s", pid, mdl)
+							logger.Debugf(ctx, "[DELETE] TOOL-USE: Auto-delete enabled, projectId=%s, model=%s", pid, mdl)
 							delClient := cycletls.Init()
 							defer safeClose(delClient)
 							if _, err := makeDeleteRequest(gc, delClient, ck, pid); err != nil {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,10 @@ import (
 )
 
 func main() {
+	// Pass log directory from command line flag to logger
+	if *common.LogDir != "" {
+		logger.LogDir = *common.LogDir
+	}
 	logger.SetupLogger()
 	logger.SysLog(fmt.Sprintf("genspark2api %s starting...", common.Version))
 

--- a/main.go
+++ b/main.go
@@ -9,9 +9,10 @@ import (
 	"genspark2api/middleware"
 	"genspark2api/router"
 	"genspark2api/yescaptcha"
-	"github.com/gin-gonic/gin"
 	"os"
 	"strconv"
+
+	"github.com/gin-gonic/gin"
 )
 
 func main() {
@@ -31,6 +32,11 @@ func main() {
 	config.YescaptchaClient = yescaptcha.NewClient(config.YesCaptchaClientKey, nil)
 
 	config.GlobalSessionManager = config.NewSessionManager()
+
+	// Log configuration summary (without secrets)
+	for _, line := range config.GetConfigSummary() {
+		logger.SysLog(line)
+	}
 
 	// 定时任务 每天9点整重载GS_COOKIES
 	//go job.LoadCookieTask()

--- a/model/genspark.go
+++ b/model/genspark.go
@@ -1,0 +1,14 @@
+package model
+
+type GensparkLoginResponse struct {
+	Status  int               `json:"status"`
+	Message string            `json:"message"`
+	Data    GensparkLoginData `json:"data"`
+}
+
+type GensparkLoginData struct {
+	CogenID    string `json:"cogen_id"`
+	CogenName  string `json:"cogen_name"`
+	CogenEmail string `json:"cogen_email"`
+	IsLogin    bool   `json:"is_login"`
+}

--- a/model/openai.go
+++ b/model/openai.go
@@ -116,8 +116,9 @@ type OpenAIChoice struct {
 }
 
 type OpenAIMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role             string `json:"role"`
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 type OpenAIUsage struct {
@@ -127,8 +128,9 @@ type OpenAIUsage struct {
 }
 
 type OpenAIDelta struct {
-	Content string `json:"content"`
-	Role    string `json:"role"`
+	Content          string `json:"content,omitempty"`
+	Role             string `json:"role,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 type OpenAIImagesGenerationRequest struct {

--- a/model/openai.go
+++ b/model/openai.go
@@ -146,36 +146,43 @@ type OpenAIChatCompletionResponse struct {
 	Created           int64          `json:"created"`
 	Model             string         `json:"model"`
 	Choices           []OpenAIChoice `json:"choices"`
-	Usage             OpenAIUsage    `json:"usage"`
+	Usage             *OpenAIUsage   `json:"usage,omitempty"`
 	SystemFingerprint *string        `json:"system_fingerprint"`
 	Suggestions       []string       `json:"suggestions"`
 }
 
 type OpenAIChoice struct {
-	Index        int           `json:"index"`
-	Message      OpenAIMessage `json:"message"`
-	LogProbs     *string       `json:"logprobs"`
-	FinishReason *string       `json:"finish_reason"`
-	Delta        OpenAIDelta   `json:"delta"`
+	Index        int            `json:"index"`
+	Message      *OpenAIMessage `json:"message,omitempty"`
+	LogProbs     *string        `json:"logprobs"`
+	FinishReason *string        `json:"finish_reason"`
+	Delta        *OpenAIDelta   `json:"delta,omitempty"`
 }
 
 type OpenAIMessage struct {
 	Role             string           `json:"role"`
 	Content          string           `json:"content"`
 	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	Reasoning        string           `json:"reasoning,omitempty"`
 	ToolCalls        []OpenAIToolCall `json:"tool_calls,omitempty"`
 }
 
 type OpenAIUsage struct {
-	PromptTokens     int `json:"prompt_tokens"`
-	CompletionTokens int `json:"completion_tokens"`
-	TotalTokens      int `json:"total_tokens"`
+	PromptTokens            int                            `json:"prompt_tokens"`
+	CompletionTokens        int                            `json:"completion_tokens"`
+	TotalTokens             int                            `json:"total_tokens"`
+	CompletionTokensDetails *OpenAICompletionTokensDetails `json:"completion_tokens_details,omitempty"`
+}
+
+type OpenAICompletionTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens"`
 }
 
 type OpenAIDelta struct {
 	Content          string                `json:"content,omitempty"`
 	Role             string                `json:"role,omitempty"`
 	ReasoningContent string                `json:"reasoning_content,omitempty"`
+	Reasoning        string                `json:"reasoning,omitempty"`
 	ToolCalls        []OpenAIDeltaToolCall `json:"tool_calls,omitempty"`
 }
 

--- a/tooluse/stream_parser.go
+++ b/tooluse/stream_parser.go
@@ -1,0 +1,190 @@
+package tooluse
+
+import (
+	"strings"
+)
+
+type ParserState int
+
+const (
+	StateInit ParserState = iota
+	// We are searching for a key in the main object
+	StateInObject
+	// We are reading a key string
+	StateInKey
+	// We have read a key, waiting for colon
+	StateColon
+	// We are reading a value
+	StateInValue
+)
+
+type StreamParser struct {
+	cursor int
+
+	// State
+	state      ParserState
+	currentKey string
+	inString   bool
+	isEscaped  bool
+
+	// Hierarchy tracking
+	stackDepth int
+
+	// Detected fields
+	ResponseType string
+	ToolName     string
+
+	// Buffering
+	tempBuffer strings.Builder // for keys and "type" value
+}
+
+type ParseEvent struct {
+	Type    string // "content" or "tool_call_inc"
+	Content string
+	Tool    string
+}
+
+func NewStreamParser() *StreamParser {
+	return &StreamParser{
+		stackDepth: 0,
+		state:      StateInit,
+	}
+}
+
+func (sp *StreamParser) Process(chunk string) ([]ParseEvent, error) {
+	var events []ParseEvent
+
+	for _, char := range chunk {
+		prevDepth := sp.stackDepth
+
+		// --- String State Handling ---
+		if sp.inString {
+			if sp.isEscaped {
+				sp.isEscaped = false
+
+				// Handle specific captures
+				if sp.state == StateInKey {
+					sp.tempBuffer.WriteRune(char)
+				} else if sp.state == StateInValue {
+					switch sp.currentKey {
+					case "type", "tool":
+						sp.tempBuffer.WriteRune(char)
+					case "content":
+						if sp.ResponseType == "response" {
+							// Unescape logic
+							var val string
+							switch char {
+							case 'n':
+								val = "\n"
+							case 'r':
+								val = "\r"
+							case 't':
+								val = "\t"
+							case '"':
+								val = "\""
+							case '\\':
+								val = "\\"
+							case '/':
+								val = "/"
+							case 'b':
+								val = "\b"
+							case 'f':
+								val = "\f"
+							default:
+								val = "\\" + string(char)
+							}
+							events = append(events, ParseEvent{Type: "content", Content: val})
+						}
+					}
+				}
+
+			} else {
+				if char == '\\' {
+					sp.isEscaped = true
+				} else if char == '"' {
+					sp.inString = false
+					// End of string handling
+					if sp.state == StateInKey {
+						sp.currentKey = sp.tempBuffer.String()
+						sp.tempBuffer.Reset()
+						sp.state = StateColon
+					} else if sp.state == StateInValue {
+						if sp.currentKey == "type" {
+							sp.ResponseType = sp.tempBuffer.String()
+							sp.tempBuffer.Reset()
+						}
+						if sp.currentKey == "tool" {
+							sp.ToolName = sp.tempBuffer.String()
+							sp.tempBuffer.Reset()
+						}
+						sp.state = StateInObject
+					}
+				} else {
+					// Normal char inside string
+					if sp.state == StateInKey {
+						sp.tempBuffer.WriteRune(char)
+					} else if sp.state == StateInValue {
+						switch sp.currentKey {
+						case "type", "tool":
+							sp.tempBuffer.WriteRune(char)
+						case "content":
+							if sp.ResponseType == "response" {
+								events = append(events, ParseEvent{Type: "content", Content: string(char)})
+							}
+						}
+					}
+				}
+			}
+
+		} else {
+			// --- Not Handle String ---
+			switch char {
+			case '{':
+				sp.stackDepth++
+				if sp.stackDepth == 1 {
+					sp.state = StateInObject
+				}
+			case '}':
+				sp.stackDepth--
+				if sp.stackDepth == 1 {
+					// Closed inner object, back to outer object
+					sp.state = StateInObject
+				}
+			case '"':
+				sp.inString = true
+				if sp.state == StateInObject {
+					sp.state = StateInKey
+				}
+			case ':':
+				if sp.state == StateColon {
+					sp.state = StateInValue
+				}
+			case ',':
+				if sp.state == StateInValue && sp.stackDepth == 1 {
+					sp.state = StateInObject
+					sp.currentKey = ""
+				}
+			}
+		}
+
+		// --- Emission Logic for Arguments ---
+		if sp.ResponseType == "tool_call" {
+			// Rule: Everything inside arguments value is emitted as raw JSON
+			// Arguments value is the ONLY object at depth > 1 (assuming simplistic tool call structure)
+			shouldEmit := false
+
+			if sp.stackDepth > 1 {
+				shouldEmit = true
+			} else if sp.stackDepth == 1 && prevDepth == 2 {
+				// Just closed arguments object
+				shouldEmit = true
+			}
+
+			if shouldEmit && sp.ToolName != "" {
+				events = append(events, ParseEvent{Type: "tool_call_inc", Content: string(char), Tool: sp.ToolName})
+			}
+		}
+	}
+
+	return events, nil
+}

--- a/tooluse/stream_parser_test.go
+++ b/tooluse/stream_parser_test.go
@@ -1,0 +1,97 @@
+package tooluse
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStreamParser_Process_Content(t *testing.T) {
+	parser := NewStreamParser()
+
+	chunks := []string{
+		`{"type"`,
+		`:"response",`,
+		`"content":"Hello`,
+		` World!"}`,
+	}
+
+	expected := []string{"H", "e", "l", "l", "o", " ", "W", "o", "r", "l", "d", "!"}
+	var actual []string
+
+	for _, chunk := range chunks {
+		events, err := parser.Process(chunk)
+		if err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		for _, e := range events {
+			if e.Type == "content" {
+				// We might get multiple chars in one event or multiple events
+				// Actually current impl sends one char per event mostly
+				actual = append(actual, e.Content)
+			}
+		}
+	}
+
+	fullActual := strings.Join(actual, "")
+	fullExpected := strings.Join(expected, "")
+
+	if fullActual != fullExpected {
+		t.Errorf("Expected content %q, got %q", fullExpected, fullActual)
+	}
+}
+
+func TestStreamParser_Process_ToolCall(t *testing.T) {
+	parser := NewStreamParser()
+
+	chunks := []string{
+		`{"type":"tool_call","tool":"get_weather","arguments":{"ci`,
+		`ty":"Paris"}}`,
+	}
+
+	var actualArgs strings.Builder
+	var toolName string
+
+	for _, chunk := range chunks {
+		events, err := parser.Process(chunk)
+		if err != nil {
+			t.Fatalf("Process error: %v", err)
+		}
+		for _, e := range events {
+			if e.Type == "tool_call_inc" {
+				actualArgs.WriteString(e.Content)
+				if e.Tool != "" {
+					toolName = e.Tool
+				}
+			}
+		}
+	}
+
+	if toolName != "get_weather" {
+		t.Errorf("Expected tool name get_weather, got %q", toolName)
+	}
+
+	expectedArgs := `{"city":"Paris"}`
+	if actualArgs.String() != expectedArgs {
+		t.Errorf("Expected args %q, got %q", expectedArgs, actualArgs.String())
+	}
+}
+
+func TestStreamParser_Process_Escaped(t *testing.T) {
+	parser := NewStreamParser()
+
+	// Test escaped quote and newline
+	input := `{"type":"response","content":"Line 1\nLine \"2\""}`
+
+	events, _ := parser.Process(input)
+	var content strings.Builder
+	for _, e := range events {
+		if e.Type == "content" {
+			content.WriteString(e.Content)
+		}
+	}
+
+	expected := "Line 1\nLine \"2\""
+	if content.String() != expected {
+		t.Errorf("Expected content %q, got %q", expected, content.String())
+	}
+}

--- a/tooluse/tooluse.go
+++ b/tooluse/tooluse.go
@@ -1,0 +1,333 @@
+package tooluse
+
+import (
+	"encoding/json"
+	"fmt"
+	"genspark2api/model"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// ToolCallResponse represents the expected JSON format from the model when calling a tool
+type ToolCallResponse struct {
+	Type      string                 `json:"type"`                // "tool_call" or "response"
+	Tool      string                 `json:"tool,omitempty"`      // function name
+	Arguments map[string]interface{} `json:"arguments,omitempty"` // function arguments
+	Content   string                 `json:"content,omitempty"`   // final response content
+}
+
+// GenerateToolSystemPrompt creates a system prompt that instructs the model
+// to use a specific JSON format for tool calls
+func GenerateToolSystemPrompt(tools []model.OpenAITool) string {
+	if len(tools) == 0 {
+		return ""
+	}
+
+	var toolDescriptions []string
+	for _, tool := range tools {
+		if tool.Type != "function" {
+			continue
+		}
+
+		desc := fmt.Sprintf("- %s", tool.Function.Name)
+		if tool.Function.Description != "" {
+			desc += fmt.Sprintf(": %s", tool.Function.Description)
+		}
+
+		// Add parameters info if available
+		if tool.Function.Parameters != nil {
+			if paramsBytes, err := json.Marshal(tool.Function.Parameters); err == nil {
+				desc += fmt.Sprintf("\n  Parameters: %s", string(paramsBytes))
+			}
+		}
+		toolDescriptions = append(toolDescriptions, desc)
+	}
+
+	if len(toolDescriptions) == 0 {
+		return ""
+	}
+
+	prompt := `You are a function-calling AI. You have access to external tools and MUST use them.
+
+AVAILABLE TOOLS:
+` + strings.Join(toolDescriptions, "\n") + `
+
+STRICT RULES - FOLLOW EXACTLY:
+
+1. You MUST call a tool when the user's request requires external data (weather, time, calculations, web search, etc.)
+
+2. Your response MUST be ONLY this JSON format, nothing else:
+{"type":"tool_call","tool":"<TOOL_NAME>","arguments":{<ARGS>}}
+
+3. If you already have tool results (shown as [Tool Result for ...]), use them to answer:
+{"type":"response","content":"<your answer based on tool results>"}
+
+4. If no tool is needed and you can answer from your knowledge:
+{"type":"response","content":"<your answer>"}
+
+5. FORBIDDEN:
+   - Do NOT explain why you can't get data
+   - Do NOT say "I don't have access to..."
+   - Do NOT write anything except the JSON
+   - Do NOT use markdown or code blocks
+   - Do NOT apologize
+
+6. The user asks about weather and no tool result is available? CALL get_weather.
+   If [Tool Result] with weather data is present? Use it to respond.
+
+EXAMPLE - User asks "What's the weather in Paris?" (no tool result yet):
+{"type":"tool_call","tool":"get_weather","arguments":{"city":"Paris"}}
+
+EXAMPLE - After tool result is received:
+{"type":"response","content":"The weather in Paris is sunny, 22°C."}
+
+YOUR RESPONSE MUST START WITH { AND END WITH } - NOTHING ELSE.`
+
+	return prompt
+}
+
+// ParseToolCallFromText attempts to parse a tool call from the model's text response
+func ParseToolCallFromText(text string) (*ToolCallResponse, error) {
+	text = strings.TrimSpace(text)
+
+	// Try to find JSON in the text
+	startIdx := strings.Index(text, "{")
+	endIdx := strings.LastIndex(text, "}")
+
+	if startIdx == -1 || endIdx == -1 || endIdx < startIdx {
+		return nil, fmt.Errorf("no valid JSON found in response")
+	}
+
+	jsonStr := text[startIdx : endIdx+1]
+
+	var response ToolCallResponse
+	if err := json.Unmarshal([]byte(jsonStr), &response); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	// Validate the response
+	if response.Type != "tool_call" && response.Type != "response" {
+		return nil, fmt.Errorf("invalid response type: %s (expected 'tool_call' or 'response')", response.Type)
+	}
+
+	if response.Type == "tool_call" && response.Tool == "" {
+		return nil, fmt.Errorf("tool_call missing tool name")
+	}
+
+	return &response, nil
+}
+
+// ConvertToOpenAIToolCall converts our ToolCallResponse to OpenAI format
+func ConvertToOpenAIToolCall(toolResp *ToolCallResponse) (*model.OpenAIToolCall, error) {
+	if toolResp.Type != "tool_call" {
+		return nil, fmt.Errorf("not a tool call response")
+	}
+
+	argsJSON, err := json.Marshal(toolResp.Arguments)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+	}
+
+	return &model.OpenAIToolCall{
+		ID:   "call_" + uuid.New().String()[:8],
+		Type: "function",
+		Function: model.OpenAIToolCallFunction{
+			Name:      toolResp.Tool,
+			Arguments: string(argsJSON),
+		},
+	}, nil
+}
+
+// IsToolCallResponse checks if the parsed response is a tool call
+func IsToolCallResponse(resp *ToolCallResponse) bool {
+	return resp != nil && resp.Type == "tool_call"
+}
+
+// IsContentResponse checks if the parsed response is a final content response
+func IsContentResponse(resp *ToolCallResponse) bool {
+	return resp != nil && resp.Type == "response"
+}
+
+// ValidateToolCall checks if a tool call is valid against the available tools
+func ValidateToolCall(toolResp *ToolCallResponse, tools []model.OpenAITool) error {
+	if toolResp.Type != "tool_call" {
+		return nil // not a tool call, nothing to validate
+	}
+
+	for _, tool := range tools {
+		if tool.Type == "function" && tool.Function.Name == toolResp.Tool {
+			return nil // found matching tool
+		}
+	}
+
+	return fmt.Errorf("unknown tool: %s", toolResp.Tool)
+}
+
+// HasTools checks if the request contains any tools
+func HasTools(req *model.OpenAIChatCompletionRequest) bool {
+	return len(req.Tools) > 0
+}
+
+// PrependToolSystemMessage adds the tool system prompt to the messages
+// It respects existing system messages by appending to them
+func PrependToolSystemMessage(messages []model.OpenAIChatMessage, tools []model.OpenAITool) []model.OpenAIChatMessage {
+	toolPrompt := GenerateToolSystemPrompt(tools)
+	if toolPrompt == "" {
+		return messages
+	}
+
+	// First, convert any tool-related messages to text format
+	messages = ConvertToolMessagesToText(messages)
+
+	// Check if there's already a system message
+	hasSystemMessage := false
+	for i, msg := range messages {
+		if msg.Role == "system" {
+			hasSystemMessage = true
+			// Append tool instructions to existing system message
+			if content, ok := msg.Content.(string); ok {
+				messages[i].Content = content + "\n\n" + toolPrompt
+			}
+			break
+		}
+	}
+
+	// If no system message exists, prepend one
+	if !hasSystemMessage {
+		systemMsg := model.OpenAIChatMessage{
+			Role:    "system",
+			Content: toolPrompt,
+		}
+		messages = append([]model.OpenAIChatMessage{systemMsg}, messages...)
+	}
+
+	return messages
+}
+
+// ConvertToolMessagesToText converts assistant messages with tool_calls and tool result messages
+// to a text format that Genspark can understand
+func ConvertToolMessagesToText(messages []model.OpenAIChatMessage) []model.OpenAIChatMessage {
+	var result []model.OpenAIChatMessage
+
+	for _, msg := range messages {
+		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+			// Convert assistant tool_calls to text representation
+			var toolCallsText strings.Builder
+			toolCallsText.WriteString("[Assistant called tools]:\n")
+			for _, tc := range msg.ToolCalls {
+				toolCallsText.WriteString(fmt.Sprintf("- %s(%s)\n", tc.Function.Name, tc.Function.Arguments))
+			}
+			// Also include content if present
+			if msg.Content != nil {
+				if s, ok := msg.Content.(string); ok && s != "" {
+					toolCallsText.WriteString("\nAssistant message: " + s)
+				}
+			}
+			result = append(result, model.OpenAIChatMessage{
+				Role:    "assistant",
+				Content: toolCallsText.String(),
+			})
+		} else if msg.Role == "tool" {
+			// Convert tool result to user message with context
+			content := ""
+			if msg.Content != nil {
+				if s, ok := msg.Content.(string); ok {
+					content = s
+				}
+			}
+			result = append(result, model.OpenAIChatMessage{
+				Role:    "user",
+				Content: fmt.Sprintf("[Tool Result for %s]: %s", msg.ToolCallID, content),
+			})
+		} else if msg.Role == "user" || msg.Role == "system" {
+			// Always include user and system messages
+			result = append(result, msg)
+		} else if msg.Role == "assistant" {
+			// Include regular assistant messages (without tool_calls)
+			result = append(result, msg)
+		} else {
+			// Include any other messages
+			result = append(result, msg)
+		}
+	}
+
+	return result
+}
+
+// StreamBuffer helps accumulate streaming chunks for JSON validation
+type StreamBuffer struct {
+	buffer       strings.Builder
+	braceCount   int
+	bracketCount int
+	inString     bool
+	escapeNext   bool
+	hasStarted   bool
+}
+
+// NewStreamBuffer creates a new StreamBuffer
+func NewStreamBuffer() *StreamBuffer {
+	return &StreamBuffer{}
+}
+
+// Append adds content to the buffer and returns true if we might have complete JSON
+func (sb *StreamBuffer) Append(content string) bool {
+	for _, ch := range content {
+		sb.buffer.WriteRune(ch)
+
+		if sb.escapeNext {
+			sb.escapeNext = false
+			continue
+		}
+
+		if ch == '\\' && sb.inString {
+			sb.escapeNext = true
+			continue
+		}
+
+		if ch == '"' {
+			sb.inString = !sb.inString
+			continue
+		}
+
+		if sb.inString {
+			continue
+		}
+
+		switch ch {
+		case '{':
+			sb.hasStarted = true
+			sb.braceCount++
+		case '}':
+			sb.braceCount--
+		case '[':
+			sb.bracketCount++
+		case ']':
+			sb.bracketCount--
+		}
+	}
+
+	// JSON might be complete if we've started and all braces/brackets are balanced
+	return sb.hasStarted && sb.braceCount == 0 && sb.bracketCount == 0
+}
+
+// GetContent returns the accumulated content
+func (sb *StreamBuffer) GetContent() string {
+	return sb.buffer.String()
+}
+
+// Reset clears the buffer
+func (sb *StreamBuffer) Reset() {
+	sb.buffer.Reset()
+	sb.braceCount = 0
+	sb.bracketCount = 0
+	sb.inString = false
+	sb.escapeNext = false
+	sb.hasStarted = false
+}
+
+// IsValidStart checks if the buffer starts with a valid JSON object
+func (sb *StreamBuffer) IsValidStart() bool {
+	content := strings.TrimSpace(sb.buffer.String())
+	return strings.HasPrefix(content, "{")
+}


### PR DESCRIPTION
Added tool_use support via messages(openAI like API now support it). 
And more flexible Debug output.

## Summary
- add granular debug flags (body/headers/payloads/log level) and surface them in the startup config summary for easier incident triage
- introduce structured logger with subsystem tags (HTTP, TOOL, COOKIE, GENSPARK, SCHED, SYS) to correlate events across components
- extend OpenAI chat models to carry tool call payloads (messages + streaming deltas) and keep system + last user messages for context clarity
- rework chat controller to log conversations, filter noise, and react properly to tool calls, enabling reliable downstream processing
- implement unified tool-use runtime that logs and executes tool calls using the new logger for observability